### PR TITLE
Update vsts-agent Dockerfile to support SQL tools for MI Data Platform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,15 +56,31 @@ RUN apt-add-repository -y ppa:openjdk-r/ppa \
   && apt-get install -y --no-install-recommends openjdk-8-jdk \
   && rm -rf /var/lib/apt/lists/* \
   && update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+
 ENV JAVA_HOME_8_X64=/usr/lib/jvm/java-8-openjdk-amd64 \
     JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 \
     JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
 
 # Install Docker
-RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - > /dev/null \
   && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
   && apt-get update \
   && apt-get install -y docker-ce
+
+# Install SQLPackage
+RUN mkdir /opt/sqlpackage \
+    && wget -O sqlpackage-linux.zip ${SQLPACKAGE_URL} \
+    && unzip sqlpackage-linux.zip -d /opt/sqlpackage \
+    && chmod a+x /opt/sqlpackage/sqlpackage \
+    && ln -s /opt/sqlpackage/sqlpackage /usr/bin/sqlpackage
+
+# Install MSSQL Tools
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - > /dev/null \
+    && curl https://packages.microsoft.com/config/ubuntu/18.04/prod.list | tee /etc/apt/sources.list.d/msprod.list \
+    && apt-get update \
+    && ACCEPT_EULA=Y apt-get install mssql-tools unixodbc-dev \
+    && ln -s /opt/mssql-tools/bin/sqlcmd /usr/bin/sqlcmd \
+    && ln -s /opt/mssql-tools/bin/bcp /usr/bin/bcp
 
 WORKDIR /azp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 # To make it easier for build and release pipelines to run apt-get,
 # configure apt to not require confirmation (assume the -y argument by default)
 ENV DEBIAN_FRONTEND=noninteractive
 RUN echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/90assumeyes
+
+# Add SQLPackage URL
+ARG SQLPACKAGE_URL=https://go.microsoft.com/fwlink/?linkid=2143497
 
 RUN apt-get update \
 && apt-get install -y --no-install-recommends \
@@ -12,29 +15,36 @@ RUN apt-get update \
         jq \
         git \
         iputils-ping \
-        libcurl3 \
-        libicu55 \
+        libcurl4 \
+        libicu60 \
+        libunwind8 \
         lsb-release \
 	      make \
+        netcat \
+        libssl1.0 \
         apt-transport-https \
         software-properties-common \
-        apt-utils
+        apt-utils \
+        wget \
+        unzip \
+        zip \
+        gnupg
 
-ENV AZ_VERSION 2.0.67-1~xenial
+ENV AZ_VERSION 2.13.0-1~bionic
 
 # Install Azure CLI
 RUN rm -rf /var/lib/apt/lists/* \
   && echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" \
   | tee /etc/apt/sources.list.d/azure-cli.list \
-  && curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | tee /etc/apt/sources.list.d/microsoft.list \
-  && curl -L https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
+  && wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb\
+  && dpkg -i packages-microsoft-prod.deb \
+  && apt-get update \
+  && add-apt-repository universe \
+  && apt-get install powershell \
+  && curl -sL https://packages.microsoft.com/keys/microsoft.asc | apt-key add - > /dev/null \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
-       apt-transport-https \
        azure-cli=$AZ_VERSION \
-       powershell \
-       zip \
-       unzip \
   && curl -sL https://deb.nodesource.com/setup_10.x | bash - \
   && apt-get install -y nodejs \
   && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
### JIRA link (if applicable) ###
[https://tools.hmcts.net/jira/browse/RDO-9554](url)


### Change description ###
Update existing self-hosted agent docker image with the below:

- Upgrade Ubuntu version to 18.04 (20.04 currently does not support Powershell, libicu package and mssql-tools)
- Install SQLPackage to allow publishing of DACPAC files
- Install MSSQL-Tools to allow use of sqlcmd and bap
- Updated AZ cli version to 2.13.0-1~bionic


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
